### PR TITLE
fix: Ensure proper resolution of $ref references in path parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ function extract(obj, options) {
     for (let p in paths) {
         if (obj.paths[p] && obj.paths[p].parameters) {
             src.paths[p].parameters = clone(obj.paths[p].parameters);
+            deref(src.paths[p].parameters,src,obj);
         }
     }
 


### PR DESCRIPTION
### Problem Description

The `openapi-extract` tool does not currently copy the contents of `#/components/parameters/<param_name>` when a `$ref` is used at the `#/paths/<path>/parameters` level.

### Steps to Replicate the Problem

Using the following OpenAPI specification: [PagerDuty API Schema](https://github.com/PagerDuty/api-schema/blob/main/reference/REST/openapiv3.json).

Run the command:

```bash
openapi-extract -d -r -x -v openapiv3.json -o getAnalyticsIncidentsById
```

This results in `#/components/parameters/id` being referenced but not correctly copied into the final spec's `components` block.

### Solution
This patch adds a `deref(...)` call after cloning the path parameters block. This ensures that the `$ref` references are properly resolved, resulting in a valid and complete spec file.